### PR TITLE
Add duplicate = false flag on vm create

### DIFF
--- a/molecule/vm/cleanup.yml
+++ b/molecule/vm/cleanup.yml
@@ -1,6 +1,7 @@
 ---
 - name: Cleanup
   hosts: all
+  gather_facts: false
   vars:
     ansible_connection: winrm
     ansible_port: 5986

--- a/molecule/vm/converge.yml
+++ b/molecule/vm/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  gather_facts: false
   vars:
     ansible_connection: winrm
     ansible_port: 5986

--- a/molecule/vm/create.yml
+++ b/molecule/vm/create.yml
@@ -14,6 +14,7 @@
         name: LAB-Test
         state: present
       register: info
+    - debug: msg="{{ info }}"
     - ansible.builtin.assert:
         that:
         - info is defined

--- a/molecule/vm/verify.yml
+++ b/molecule/vm/verify.yml
@@ -1,6 +1,7 @@
 ---
 - name: Verify
   hosts: all
+  gather_facts: false
   vars:
     ansible_connection: winrm
     ansible_port: 5986
@@ -9,3 +10,23 @@
     ansible_winrm_server_cert_validation: ignore
   
   tasks:
+
+    - name: Create simple test-VM - this should not create a new vm - ie changed = false
+      gocallag.hyperv.vm:
+        name: LAB-Test
+        state: present
+      register: info
+    - ansible.builtin.assert:
+        that:
+        - info is defined
+        - info.changed == false
+    - name: Create simple test-VM - this should create a new vm - ie changed = true
+      gocallag.hyperv.vm:
+        name: LAB-Test
+        duplicate: true
+        state: present
+      register: info
+    - ansible.builtin.assert:
+        that:
+        - info is defined
+        - info.changed == true

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -24,6 +24,11 @@ options:
       - present
       - absent
     default: null
+  duplicate:
+    description:
+    - Allow duplicate VM names
+    required: false
+    default: false
   VHDPath:
     description:
       - Specify path of VHD/VHDX file for the new VM. If the file already exists then it will be attached to the VM, if not then a new one will be created with size VHDSize


### PR DESCRIPTION
This adds an option called 'duplicate' on the vm module. This makes the default action on VM create to *not* create a duplicate VM name even though hyper-v allows it. It is possible to get the default hyper-v behaviour by having duplicate: true in the playbook.

If duplicate equals true then the module will always return changed: true

Closes #36 